### PR TITLE
70 support passing llm parameters to tasks and chats both in the decorator as well as in runtime

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,12 @@ repos:
     rev: v8.16.1
     hooks:
       - id: gitleaks
+  - repo: https://github.com/codespell-project/codespell
+    rev: "v2.2.1"
+    hooks:
+      - id: codespell
+        args:
+          - src/declarai/operators/shared/templates/
+
+
+

--- a/src/declarai/decorators/base.py
+++ b/src/declarai/decorators/base.py
@@ -1,20 +1,20 @@
 from abc import abstractmethod
-from typing import Any, List, Optional
-
-from declarai.middlewares.base import TaskMiddleware
+from typing import Any
 
 
 class LLMOrchestratorDecorator:
     def __init__(
         self,
         declarai_instance,
-        middlewares: Optional[List[TaskMiddleware]] = None,
         **kwargs,
     ):
+        """
+         Initializes the LLMOrchestratorDecorator instance.
+         :param kwargs: Additional keyword arguments.
+         """
         self.declarai_instance = declarai_instance
 
         self.operator = self.get_operator(**kwargs)
-        self.middlewares = middlewares or []
 
     @abstractmethod
     def get_operator(self, **kwargs):

--- a/src/declarai/decorators/chat_decorator.py
+++ b/src/declarai/decorators/chat_decorator.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import overload, List, Type, Callable, Any
+from typing import overload, List, Type, Callable, Any, Optional, Dict
 from typing_extensions import Self
 from declarai.decorators.base import LLMOrchestratorDecorator
 from declarai.middlewares.base import TaskMiddleware
@@ -22,8 +22,16 @@ class LLMChatDecorator(LLMOrchestratorDecorator):
         self,
         decorated=None,
         *,
-        middlewares: List[TaskMiddleware] = None
+        middlewares: List[TaskMiddleware] = None,
+        llm_params: Optional[Dict[str, Any]] = None,
     ):
+        """
+        Decorates a the python class to be a LLMChatOrchestrator
+        :param decorated: the class
+        :param middlewares: the middlewares to use while executing the chat
+        :param llm_params: the llm params like temperature, top_k, top_p, etc to be used when prompting the chat
+        :return:
+        """
         # When arguments are passed
         if decorated is None:
             self.middlewares = middlewares

--- a/src/declarai/decorators/task_decorator.py
+++ b/src/declarai/decorators/task_decorator.py
@@ -1,4 +1,4 @@
-from typing import overload, Callable, Any, List, Type
+from typing import overload, Callable, Any, List, Type, Optional, Dict
 from typing_extensions import Self
 from declarai.decorators.base import LLMOrchestratorDecorator
 from declarai.middlewares.base import TaskMiddleware
@@ -8,22 +8,30 @@ from declarai.orchestrator.task_orchestrator import LLMTaskOrchestrator
 
 class LLMTaskDecorator(LLMOrchestratorDecorator):
     @overload
-    def __call__(self, decorated: None = None, *, middlewares: List[Type[TaskMiddleware]]) -> Self:
+    def __call__(self, decorated: None = None, **kwargs) -> Self:
         ...
 
     @overload
-    def __call__(self, decorated: Callable[..., Any]) -> LLMTaskOrchestrator:
+    def __call__(self, decorated: Callable[..., Any], **kwargs) -> LLMTaskOrchestrator:
         ...
 
     def __call__(
         self,
         decorated=None,
         *,
-        middlewares: List[TaskMiddleware] = None
+        middlewares: List[TaskMiddleware] = None,
+        llm_params: Optional[Dict[str, Any]] = None,
     ):
+        """
+        Decorates a python function to be a LLMTaskOrchestrator
+        :param decorated: the python function
+        :param middlewares: the middlewares to use while executing the task
+        :param llm_params: the llm params like temperature, top_k, top_p, etc to be used when prompting the task
+        """
         # When arguments are passed
         if decorated is None:
             self.middlewares = middlewares
+            self.llm_params = llm_params
             return self
         else:
             # When no arguments are passed
@@ -34,7 +42,7 @@ class LLMTaskDecorator(LLMOrchestratorDecorator):
 
     def return_orchestrator(self, func):
         llm_task = LLMTaskOrchestrator(
-            func, self.operator, middlewares=self.middlewares
+            func, self.operator, middlewares=self.middlewares, llm_params=self.llm_params
         )
         llm_task.__name__ = func.__name__
         return llm_task

--- a/src/declarai/operators/base/types/operator.py
+++ b/src/declarai/operators/base/types/operator.py
@@ -9,16 +9,17 @@ CompiledTemplate = TypeVar("CompiledTemplate")
 
 class BaseOperator(ABC):
     llm: LLM
-    llm_params: Optional[Dict[str, Any]] = {}
 
-    def __init__(self, llm: LLM, parsed: PythonParser, **kwargs):
+    def __init__(self, llm: LLM, parsed: PythonParser, llm_params: Optional[Dict[str, Any]] = None, **kwargs):
         self.llm = llm
         self.parsed = parsed
         self.llm_response = None
+        self.llm_params = llm_params
 
     @abstractmethod
     def compile(self, **kwargs) -> CompiledTemplate:
         ...
 
-    def predict(self, **kwargs) -> LLMResponse:
-        return self.llm.predict(**self.compile(**kwargs), **self.llm_params)
+    def predict(self, llm_params: Optional[Dict[str, Any]], **kwargs) -> LLMResponse:
+        llm_params = llm_params or self.llm_params
+        return self.llm.predict(**self.compile(**kwargs), **llm_params)

--- a/src/declarai/operators/base/types/operator.py
+++ b/src/declarai/operators/base/types/operator.py
@@ -14,12 +14,12 @@ class BaseOperator(ABC):
         self.llm = llm
         self.parsed = parsed
         self.llm_response = None
-        self.llm_params = llm_params
+        self.llm_params = llm_params or {}
 
     @abstractmethod
     def compile(self, **kwargs) -> CompiledTemplate:
         ...
 
-    def predict(self, llm_params: Optional[Dict[str, Any]], **kwargs) -> LLMResponse:
-        llm_params = llm_params or self.llm_params
+    def predict(self, llm_params: Optional[Dict[str, Any]] = None, **kwargs) -> LLMResponse:
+        llm_params = llm_params or self.llm_params  # Order is important!
         return self.llm.predict(**self.compile(**kwargs), **llm_params)

--- a/src/declarai/operators/openai_operators/chat_operator.py
+++ b/src/declarai/operators/openai_operators/chat_operator.py
@@ -34,7 +34,7 @@ class OpenAIChatOperator(BaseOperator):
         parsed_func: PythonParser,
         **kwargs,
     ):
-        super().__init__(llm=llm, parsed=parsed)
+        super().__init__(llm=llm, parsed=parsed, **kwargs)
         self.parsed_func = parsed_func
         self.system = kwargs.get("system", self.parsed.docstring_freeform)
 

--- a/src/declarai/operators/openai_operators/task_operator.py
+++ b/src/declarai/operators/openai_operators/task_operator.py
@@ -35,8 +35,8 @@ class OpenAITaskOperator(BaseOperator):
         partial_class = partial(cls, openai_llm)
         return partial_class
 
-    def __init__(self, llm: OpenAILLM, parsed: PythonParser):
-        super().__init__(llm, parsed)
+    def __init__(self, llm: OpenAILLM, parsed: PythonParser, **kwargs):
+        super().__init__(llm, parsed, **kwargs)
 
     def _compile_input_placeholder(self) -> str:
         """

--- a/src/declarai/operators/shared/templates/output_structure.py
+++ b/src/declarai/operators/shared/templates/output_structure.py
@@ -2,4 +2,4 @@ StructuredOutputInstructionPrompt = """You are a REST api endpoint.You only answ
 with a single key named '{return_name}', nothing else.
 The expected format is:
 {output_schema}"""
-StructuredOutputChatPrompt = """Your respones should be a JSON structure with a single key named '{return_name}', nothing else. The expected format is: {output_schema}"""
+StructuredOutputChatPrompt = """Your responses should be a JSON structure with a single key named '{return_name}', nothing else. The expected format is: {output_schema}"""

--- a/src/declarai/orchestrator/chat_orchestrator.py
+++ b/src/declarai/orchestrator/chat_orchestrator.py
@@ -3,7 +3,7 @@
 TODO...
 """
 
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from declarai.middlewares.base import TaskMiddleware
 from declarai.operators.base.types import Message, MessageRole
@@ -69,8 +69,10 @@ class LLMChatOrchestrator:
             return self.parsed_send_func.parse(raw_response)
         return raw_response
 
-    def __call__(self, **kwargs) -> Any:
+    def __call__(self, llm_params: Optional[Dict[str, Any]] = None, **kwargs) -> Any:
         self._kwargs = kwargs
+        if llm_params:
+            self._kwargs["llm_params"] = llm_params
         return self._exec_with_message_state(kwargs)
 
     def send(self, **kwargs) -> Any:

--- a/src/declarai/orchestrator/task_orchestrator.py
+++ b/src/declarai/orchestrator/task_orchestrator.py
@@ -13,7 +13,7 @@ the different LLM API providers as well as custom models have different APIs wit
 structures. For that reason, there are multiple implementations of operators, depending on the required use case.
 """
 
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Optional
 
 from declarai.middlewares.base import TaskMiddleware
 from declarai.operators.base.types.llm import LLMResponse
@@ -72,6 +72,8 @@ class LLMTaskOrchestrator:
                 return exec_with_middlewares()
         return self._exec(kwargs)
 
-    def __call__(self, **kwargs) -> Any:
+    def __call__(self, llm_params: Optional[Dict[str, Any]] = None, **kwargs) -> Any:
         self._kwargs = kwargs
+        if llm_params:
+            self._kwargs["llm_params"] = llm_params
         return self._exec_middlewares(kwargs)

--- a/tests/api/test_task_decorator.py
+++ b/tests/api/test_task_decorator.py
@@ -35,8 +35,40 @@ def test_task_decorator_no_args(mocked_resolve_operator, mocked_python_parser):
 
     assert task_decorator.declarai_instance == declarai_instance
     assert task_decorator.operator == mocked_resolve_operator.return_value
-    assert task_decorator.middlewares == middlewares
+    assert test_task.middlewares == middlewares
 
     assert test_task.__name__ == "test_task"
     assert test_task.parsed == mocked_python_parser.return_value
     assert test_task.operator == mock_operator_instance
+
+    @task_decorator(
+        middlewares=middlewares,
+        llm_params={"temperature": 0.5}
+    )
+    def test_task(a: str, b: int) -> str:
+        """
+        This is a test task
+        :param a: this is a string
+        :param b: this is an integer
+        :return: returns a string
+        """
+
+    assert test_task.llm_params == {"temperature": 0.5}
+    assert test_task.__name__ == "test_task"
+    assert test_task.middlewares == middlewares
+
+
+    @task_decorator(
+        llm_params={"temperature": 0.5}
+    )
+    def test_task(a: str, b: int) -> str:
+        """
+        This is a test task
+        :param a: this is a string
+        :param b: this is an integer
+        :return: returns a string
+        """
+
+    test_task(llm_params={"temperature": 0.7})
+    assert test_task.llm_params == {"temperature": 0.5}
+    mocked_resolve_operator().return_value.predict.assert_called_with(llm_params={"temperature": 0.7})

--- a/tests/orchestrator/test_task_orchestrator.py
+++ b/tests/orchestrator/test_task_orchestrator.py
@@ -22,6 +22,9 @@ def test_task_orchestrator():
 
     # TODO: Implement test when plan is implemented
     # task_orchestrator.plan()
-
+    #
     res = task_orchestrator()
     assert res == "predicted_result"
+
+    res = task_orchestrator(llm_params={"temperature": 0.5})
+    instantiated_operator.predict.assert_called_with(llm_params={"temperature": 0.5})


### PR DESCRIPTION
1. Removed middlewares from taskdecorator. From now on, the middlewares/llm_params and everything that should be declared for the orchestrator won't be registered under the Decorator. The goal is to make the decorator as stateless as possible.
2. Now we can pass llm_params through the decorator as well as kwarg in the task runtime.

![image](https://github.com/vendi-ai/declarai/assets/69151308/b1c780d6-3f9b-44b0-b49d-3911d2a71c15)
