### PR TITLE
Closes #77 - Support databases for chat memory (postgres, mongo and redis)

### DIFF
--- a/docs/docs/src/features/chat/chat-memory/file-memory.md
+++ b/docs/docs/src/features/chat/chat-memory/file-memory.md
@@ -9,7 +9,7 @@ from declarai import Declarai
 from declarai.memory import FileMessageHistory
 declarai = Declarai(provider="openai", model="gpt-3.5-turbo")
 
-@declarai.experimental.chat(chat_memory=FileMessageHistory("sql_bot_history.txt")) # (1)!
+@declarai.experimental.chat(chat_history=FileMessageHistory("sql_bot_history.txt")) # (1)!
 class SQLBot:
     """
     You are a sql assistant. You help with SQL related questions with one-line answers.
@@ -37,5 +37,5 @@ class SQLBot:
     You are a sql assistant. You help with SQL related questions with one-line answers.
     """
 
-sql_bot = SQLBot(chat_memory=FileMessageHistory("sql_bot_history.txt"))
+sql_bot = SQLBot(chat_history=FileMessageHistory("sql_bot_history.txt"))
 ```

--- a/docs/docs/src/features/chat/chat-memory/index.md
+++ b/docs/docs/src/features/chat/chat-memory/index.md
@@ -58,7 +58,7 @@ If you prefer to have a persistent history, you can use the `FileMessageHistory`
 
 
 ## Setting up a memory
-Setting up a memory is done by passing chat_memory as a keyword argument to the `declarai.experimental.chat` decorator.
+Setting up a memory is done by passing `chat_history` as a keyword argument to the `declarai.experimental.chat` decorator.
 
 ```py
 from declarai import Declarai
@@ -66,7 +66,7 @@ from declarai.memory import FileMessageHistory
 
 declarai = Declarai(provider="openai", model="gpt-3.5-turbo")
 
-@declarai.experimental.chat(chat_memory=FileMessageHistory("sql_bot_history.txt")) # (1)!
+@declarai.experimental.chat(chat_history=FileMessageHistory("sql_bot_history.txt")) # (1)!
 class SQLBot:
     """
     You are a sql assistant. You help with SQL related questions with one-line answers.
@@ -75,7 +75,7 @@ class SQLBot:
 
 1. file path is not mandatory. If you do not provide a file path, the default file path is stored in a tmp directory.
 
-We can also initialize the chat_memory at runtime
+We can also initialize the chat_history at runtime
 
 ```py
 from declarai import Declarai
@@ -88,7 +88,7 @@ class SQLBot:
     """
     You are a sql assistant. You help with SQL related questions with one-line answers.
     """
-sql_bot = SQLBot(chat_memory=FileMessageHistory("sql_bot_history.txt"))
+sql_bot = SQLBot(chat_history=FileMessageHistory("sql_bot_history.txt"))
 ```
 
 

--- a/docs/docs/src/features/chat/chat-memory/mongodb-memory.md
+++ b/docs/docs/src/features/chat/chat-memory/mongodb-memory.md
@@ -1,0 +1,57 @@
+
+# MongoDB Memory :material-database:
+
+For chat that requires a persistent and scalable message history, you can use a MongoDB database to store the conversation history.
+
+## Set MongoDB memory
+
+```py
+from declarai import Declarai
+from declarai.memory import MongoDBMessageHistory
+declarai = Declarai(provider="openai", model="gpt-3.5-turbo")
+
+@declarai.experimental.chat(
+    chat_history=MongoDBMessageHistory(
+        connection_string="mongodb://localhost:27017/mydatabase",
+        session_id="unique_chat_id")
+) # (1)!
+class SQLBot:
+    """
+    You are a sql assistant. You help with SQL related questions with one-line answers.
+    """
+
+sql_bot = SQLBot()
+```
+
+1. The `connection_string` parameter specifies the connection details for the MongoDB database. Replace `localhost`, `27017`, and `mydatabase` with your specific MongoDB connection details. The `session_id` parameter uniquely identifies the chat session for which the history is being stored.
+
+
+## Set MongoDB memory at runtime
+
+In case you want to set the MongoDB memory at runtime, you can use the `set_memory` method.
+
+```py
+from declarai import Declarai
+from declarai.memory import MongoDBMessageHistory
+
+declarai = Declarai(provider="openai", model="gpt-3.5-turbo")
+
+
+@declarai.experimental.chat
+class SQLBot:
+    """
+    You are a sql assistant. You help with SQL related questions with one-line answers.
+    """
+
+
+sql_bot = SQLBot(chat_history=MongoDBMessageHistory(connection_string="mongodb://localhost:27017/mydatabase",
+                                                   session_id="unique_chat_id"))
+```
+
+## Dependencies
+
+Make sure to install the following dependencies before using MongoDB memory.
+
+```bash
+pip install declarai[mongodb]
+```

--- a/docs/docs/src/features/chat/chat-memory/postgresql-memory.md
+++ b/docs/docs/src/features/chat/chat-memory/postgresql-memory.md
@@ -1,0 +1,54 @@
+
+# PostgreSQL Memory :material-database:
+
+For chat that requires a persistent message history with the advantages of scalability and robustness, you can use a PostgreSQL database to store the conversation history.
+
+## Set PostgreSQL memory
+
+```py
+from declarai import Declarai
+from declarai.memory import PostgresMessageHistory
+declarai = Declarai(provider="openai", model="gpt-3.5-turbo")
+
+@declarai.experimental.chat(
+    chat_history=PostgresMessageHistory(
+        connection_string="postgresql://username:password@localhost:5432/mydatabase",
+        session_id="unique_chat_id")
+) # (1)!
+class SQLBot:
+    """
+    You are a sql assistant. You help with SQL related questions with one-line answers.
+    """
+
+sql_bot = SQLBot()
+```
+
+1. The `connection_string` parameter specifies the connection details for the PostgreSQL database. Replace `username`, `password`, `localhost`, `5432`, and `mydatabase` with your specific PostgreSQL connection details. The `session_id` parameter uniquely identifies the chat session for which the history is being stored.
+
+
+## Set PostgreSQL memory at runtime
+
+In case you want to set the PostgreSQL memory at runtime, you can use the `set_memory` method.
+
+```py
+from declarai import Declarai
+from declarai.memory import PostgresMessageHistory
+
+declarai = Declarai(provider="openai", model="gpt-3.5-turbo")
+
+@declarai.experimental.chat
+class SQLBot:
+    """
+    You are a sql assistant. You help with SQL related questions with one-line answers.
+    """
+
+sql_bot = SQLBot(chat_history=PostgresMessageHistory(connection_string="postgresql://username:password@localhost:5432/mydatabase", session_id="unique_chat_id"))
+```
+
+## Dependencies
+
+Make sure to install the following dependencies before using PostgreSQL memory.
+
+```bash
+pip install declarai[postgresql]
+```

--- a/docs/docs/src/features/chat/chat-memory/redis-memory.md
+++ b/docs/docs/src/features/chat/chat-memory/redis-memory.md
@@ -1,0 +1,55 @@
+
+# Redis Memory :material-database:
+
+For chat that requires a fast and scalable message history, you can use a Redis database to store the conversation history.
+
+## Set Redis memory
+
+```py
+from declarai import Declarai
+from declarai.memory import RedisMessageHistory
+declarai = Declarai(provider="openai", model="gpt-3.5-turbo")
+
+@declarai.experimental.chat(
+    chat_history=RedisMessageHistory(
+        session_id="unique_chat_id",
+        url="redis://localhost:6379/0"
+    )
+) # (1)!
+class SQLBot:
+    """
+    You are a sql assistant. You help with SQL related questions with one-line answers.
+    """
+
+sql_bot = SQLBot()
+```
+
+1. The `url` parameter specifies the connection details for the Redis server. Replace `localhost` and `6379` with your specific Redis connection details. The `session_id` parameter uniquely identifies the chat session for which the history is being stored.
+
+We can also initialize the `RedisMessageHistory` class with custom connection details.
+
+## Set Redis memory at runtime
+
+In case you want to set the Redis memory at runtime, you can use the `set_memory` method.
+
+```py
+from declarai import Declarai
+from declarai.memory import RedisMessageHistory
+declarai = Declarai(provider="openai", model="gpt-3.5-turbo")
+
+@declarai.experimental.chat
+class SQLBot:
+    """
+    You are a sql assistant. You help with SQL related questions with one-line answers.
+    """
+
+sql_bot = SQLBot(chat_history=RedisMessageHistory(session_id="unique_chat_id", url="redis://localhost:6379/0"))
+```
+
+## Dependencies
+
+Make sure to install the following dependencies before using Redis memory.
+
+```bash
+pip install declarai[redis]
+```

--- a/docs/docs/src/newsletter.md
+++ b/docs/docs/src/newsletter.md
@@ -1,0 +1,33 @@
+Subscribe to our newsletter to stay up to date with the latest news about the declarai, and other cool stuff 📬
+
+<div id="mc_embed_shell">
+      <link href="//cdn-images.mailchimp.com/embedcode/classic-061523.css" rel="stylesheet" type="text/css">
+  <style type="text/css">
+        #mc_embed_signup{background:#fff; false;clear:left; font:14px Helvetica,Arial,sans-serif; width: 600px;}
+        /* Add your own Mailchimp form style overrides in your site stylesheet or in this style block.
+           We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style>
+<div id="mc_embed_signup">
+    <form action="https://github.us21.list-manage.com/subscribe/post?u=bd6960de305632e80b80668e9&amp;id=9102e996cc&amp;f_id=004763e1f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank">
+        <div id="mc_embed_signup_scroll"><h2>Subscribe</h2>
+            <div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
+            <div class="mc-field-group"><label for="mce-EMAIL">Email Address <span class="asterisk">*</span></label><input type="email" name="EMAIL" class="required email" id="mce-EMAIL" required="" value=""><span id="mce-EMAIL-HELPERTEXT" class="helper_text"></span></div><div class="mc-field-group"><label for="mce-FNAME">Company / Organization </label><input type="text" name="FNAME" class=" text" id="mce-FNAME" value=""></div><div class="mc-field-group"><label for="mce-LNAME">Full name </label><input type="text" name="LNAME" class=" text" id="mce-LNAME" value=""></div>
+        <div id="mce-responses" class="clear foot">
+            <div class="response" id="mce-error-response" style="display: none;"></div>
+            <div class="response" id="mce-success-response" style="display: none;"></div>
+        </div>
+    <div aria-hidden="true" style="position: absolute; left: -5000px;">
+        /* real people should not fill this in and expect good things - do not remove this or risk form bot signups */
+        <input type="text" name="b_bd6960de305632e80b80668e9_9102e996cc" tabindex="-1" value="">
+    </div>
+        <div class="optionalParent">
+            <div class="clear foot">
+                <input type="submit" name="subscribe" id="mc-embedded-subscribe" class="button" value="Subscribe">
+                <p style="margin: 0px auto;"><a href="http://eepurl.com/ixDUMI" title="Mailchimp - email marketing made easy and fun"><span style="display: inline-block; background-color: transparent; border-radius: 4px;"><img class="refferal_badge" src="https://digitalasset.intuit.com/render/content/dam/intuit/mc-fe/en_us/images/intuit-mc-rewards-text-dark.svg" alt="Intuit Mailchimp" style="width: 220px; height: 40px; display: flex; padding: 2px 0px; justify-content: center; align-items: center;"></span></a></p>
+            </div>
+        </div>
+    </div>
+</form>
+</div>
+<script type="text/javascript" src="//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js"></script><script type="text/javascript">(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';}(jQuery));var $mcj = jQuery.noConflict(true);</script></div>
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -33,6 +33,9 @@ nav:
           - Chat memory:
             - src/features/chat/chat-memory/index.md
             - File Memory: src/features/chat/chat-memory/file-memory.md
+            - Redis Memory: src/features/chat/chat-memory/redis-memory.md
+            - MongoDB Memory: src/features/chat/chat-memory/mongodb-memory.md
+            - PostgreSQL Memory: src/features/chat/chat-memory/postgresql-memory.md
           - Controlling chat behavior: src/features/chat/controlling-chat-behavior.md
           - Debugging chat: src/features/chat/debugging-chat.md
           - Customizing chat response: src/features/chat/customizing-chat-response.md
@@ -57,6 +60,7 @@ nav:
       - src/examples/deployments/index.md
   - Changelog: src/changelog.md
   - Contribute: src/contribute.md
+  - Newsletter: src/newsletter.md
 
 theme:
   features:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "declarai"
-version = "0.1.4"
+version = "0.1.5"
 description = "Declarai, turning Python code into LLM tasks, easy to use, and production-ready."
 authors = ["Aviv Almashanu <avivex1000@gmail.com>"]
 readme = "README.md"
@@ -25,6 +25,9 @@ mkdocs-material = "^9.1.21"
 
 [tool.poetry.extras]
 wandb = ["wandb"]
+postgresql = ["psycopg2"]
+redis = ["redis"]
+mongo = ["pymongo"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/declarai/decorators/chat_decorator.py
+++ b/src/declarai/decorators/chat_decorator.py
@@ -14,7 +14,7 @@ class LLMChatDecorator(LLMOrchestratorDecorator):
     @overload
     def __call__(self, decorated: None = None, *, middlewares: Optional[List[Type[TaskMiddleware]]] = None,
                  llm_params: Optional[Union[LLMParamsType, Dict[str, Any]]] = None,
-                 chat_memory: Optional[BaseChatMessageHistory] = None
+                 chat_history: Optional[BaseChatMessageHistory] = None
                  ) -> Callable[..., Callable[..., LLMChatOrchestrator]]:
         ...
 
@@ -28,7 +28,7 @@ class LLMChatDecorator(LLMOrchestratorDecorator):
         *,
         middlewares: List[TaskMiddleware] = None,
         llm_params: Optional[LLMParamsType] = None,
-        chat_memory: Optional[BaseChatMessageHistory] = None
+        chat_history: Optional[BaseChatMessageHistory] = None
     ):
         """
         Decorates a the python class to be a LLMChatOrchestrator
@@ -40,7 +40,7 @@ class LLMChatDecorator(LLMOrchestratorDecorator):
         # When arguments are passed
         if decorated is None:
             return partial(self.return_orchestrator, middlewares=middlewares, llm_params=llm_params,
-                           chat_memory=chat_memory)
+                           chat_history=chat_history)
         else:
             # When no arguments are passed
             return self.return_orchestrator(decorated)
@@ -60,7 +60,7 @@ class LLMChatDecorator(LLMOrchestratorDecorator):
         decorated_cls: Callable[..., Any],
         middlewares: List[Type[TaskMiddleware]] = None,
         llm_params: LLMParamsType = None,
-        chat_memory: BaseChatMessageHistory = None
+        chat_history: BaseChatMessageHistory = None
     ) -> Callable[..., LLMChatOrchestrator]:
         non_private_methods = {
             method_name: method
@@ -90,5 +90,5 @@ class LLMChatDecorator(LLMOrchestratorDecorator):
             decorated_cls,
             middlewares=middlewares,
             llm_params=llm_params,
-            chat_memory=chat_memory
+            chat_history=chat_history
         )

--- a/src/declarai/memory/__init__.py
+++ b/src/declarai/memory/__init__.py
@@ -1,2 +1,5 @@
 from .in_memory import InMemoryMessageHistory
 from .file import FileMessageHistory
+from .postgres import PostgresMessageHistory
+from .redis import RedisMessageHistory
+from .mongodb import MongoDBMessageHistory

--- a/src/declarai/memory/mongodb.py
+++ b/src/declarai/memory/mongodb.py
@@ -1,0 +1,75 @@
+import json
+import logging
+from typing import List
+from .base import BaseChatMessageHistory
+from ..operators.base.types import Message
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DBNAME = "chat_history"
+DEFAULT_COLLECTION_NAME = "message_store"
+DEFAULT_CONNECTION_STRING = "mongodb://localhost:27017"
+
+
+class MongoDBMessageHistory(BaseChatMessageHistory):
+    """
+    Chat message history that stores history in MongoDB.
+
+    Args:
+        connection_string: connection string to connect to MongoDB
+        session_id: arbitrary key that is used to store the messages
+            of a single chat session.
+        database_name: name of the database to use
+        collection_name: name of the collection to use
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        connection_string: str = DEFAULT_CONNECTION_STRING,
+        database_name: str = DEFAULT_DBNAME,
+        collection_name: str = DEFAULT_COLLECTION_NAME,
+    ):
+        try:
+            from pymongo import MongoClient
+        except ImportError:
+            raise ImportError(
+                "Could not import pymongo python package. "
+                "Please install it with `pip install pymongo`."
+            )
+
+        self.connection_string = connection_string
+        self.session_id = session_id
+        self.database_name = database_name
+        self.collection_name = collection_name
+
+        self.client: MongoClient = MongoClient(connection_string)
+        self.db = self.client[database_name]
+        self.collection = self.db[collection_name]
+        self.collection.create_index("SessionId")
+
+    @property
+    def history(self) -> List[Message]:
+        """Retrieve the messages from MongoDB"""
+        cursor = self.collection.find({"SessionId": self.session_id})
+
+        if cursor:
+            items = [json.loads(document["History"]) for document in cursor]
+        else:
+            items = []
+
+        messages = [Message.parse_obj(obj=dict_item) for dict_item in items]
+        return messages
+
+    def add_message(self, message: Message) -> None:
+        """Append the message to the record in MongoDB"""
+        self.collection.insert_one(
+            {
+                "SessionId": self.session_id,
+                "History": json.dumps(message.dict()),
+            }
+        )
+
+    def clear(self) -> None:
+        """Clear session memory from MongoDB"""
+        self.collection.delete_many({"SessionId": self.session_id})

--- a/src/declarai/memory/postgres.py
+++ b/src/declarai/memory/postgres.py
@@ -1,0 +1,82 @@
+import json
+from typing import List, Optional
+from .base import BaseChatMessageHistory
+from ..operators.base.types import Message
+import logging
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TABLE_NAME = "message_store"
+DEFAULT_CONNECTION_STRING = "postgresql://postgres:postgres@localhost:5432/postgres"
+
+
+class PostgresMessageHistory(BaseChatMessageHistory):
+    """
+    Chat message history that stores history in a PostgreSQL database.
+
+    Args:
+        connection_string: Database connection string.
+    """
+
+    def __init__(self, session_id: str, connection_string: Optional[str] = DEFAULT_CONNECTION_STRING,
+                 table_name: str = DEFAULT_TABLE_NAME):
+        try:
+            import psycopg2
+        except ImportError:
+            raise ImportError(
+                "Cannot import psycopg2."
+                "Please install psycopg2 to use PostgresMessageHistory."
+            )
+        self.conn = psycopg2.connect(connection_string)
+        self.cursor = self.conn.cursor()
+        self.table_name = table_name
+        self.session_id = session_id
+        self._initialize_tables()
+
+    def _initialize_tables(self):
+        """Initialize the tables if they don't exist."""
+        create_table_query = f"""CREATE TABLE IF NOT EXISTS {self.table_name} (
+            id SERIAL PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            message JSONB NOT NULL
+        );"""
+        self.cursor.execute(create_table_query)
+        self.conn.commit()
+
+    @property
+    def history(self) -> List[Message]:
+        """Retrieve the messages from the database."""
+        query = f"SELECT message FROM {self.table_name} WHERE session_id = %s ORDER BY id;"
+        self.cursor.execute(query, (self.session_id,))
+        rows = self.cursor.fetchall()
+        messages = [Message.parse_obj(row[0]) for row in rows]
+        return messages
+
+    def add_message(self, message: Message) -> None:
+        from psycopg2 import sql
+        """Append the message to the database."""
+        query = sql.SQL("INSERT INTO {} (session_id, message) VALUES (%s, %s);").format(
+            sql.Identifier(self.table_name)
+        )
+        self.cursor.execute(
+            query, (self.session_id, json.dumps(message.dict()))
+        )
+        self.conn.commit()
+
+    def clear(self) -> None:
+        """Clear session memory from the database."""
+        query = f"DELETE FROM {self.table_name} WHERE session_id = %s;"
+        self.cursor.execute(query, (self.session_id,))
+        self.conn.commit()
+
+    def close(self):
+        """Close cursor and connection."""
+        self.cursor.close()
+        self.conn.close()
+
+    def __del__(self):
+        """Destructor to close cursor and connection."""
+        if hasattr(self, 'cursor'):
+            self.cursor.close()
+        if hasattr(self, 'conn'):
+            self.conn.close()

--- a/src/declarai/memory/redis.py
+++ b/src/declarai/memory/redis.py
@@ -1,0 +1,66 @@
+import json
+import logging
+from typing import List, Optional
+
+from .base import BaseChatMessageHistory
+from ..operators.base.types import Message
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_TABLE_NAME = "message_store"
+DEFAULT_URL = "redis://localhost:6379/0"
+
+class RedisMessageHistory(BaseChatMessageHistory):
+    """
+    Chat message history that stores history in a Redis database.
+
+    Args:
+        session_id: ID for the chat session.
+        url: URL to connect to the Redis server.
+        key_prefix: Prefix for the Redis key.
+        ttl: Time-to-live for the message records.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        url: str = DEFAULT_URL,
+        key_prefix: str = f"{DEFAULT_TABLE_NAME}:",
+        ttl: Optional[int] = None,
+    ):
+        try:
+            import redis
+        except ImportError:
+            raise ImportError(
+                "Could not import redis python package. "
+                "Please install it with `pip install redis`."
+            )
+
+        self.redis_client = redis.StrictRedis.from_url(url)
+        self.session_id = session_id
+        self.key_prefix = key_prefix
+        self.ttl = ttl
+
+    @property
+    def key(self) -> str:
+        """Construct the record key to use"""
+        return self.key_prefix + self.session_id
+
+    @property
+    def history(self) -> List[Message]:
+        """Retrieve the messages from Redis"""
+        _items = self.redis_client.lrange(self.key, 0, -1)
+        items = [json.loads(m.decode("utf-8")) for m in _items[::-1]]
+        messages = [Message.parse_obj(obj=dict_item) for dict_item in items]
+        return messages
+
+    def add_message(self, message: Message) -> None:
+        """Append the message to the record in Redis"""
+        self.redis_client.lpush(self.key, json.dumps(message.dict()))
+        if self.ttl:
+            self.redis_client.expire(self.key, self.ttl)
+
+    def clear(self) -> None:
+        """Clear session memory from Redis"""
+        self.redis_client.delete(self.key)


### PR DESCRIPTION
add dependecies section for db chat memory

add docs for chat memory (mongo,redis,postgres) and bump version to 0.1.5

add chat message history implementations for mongo, postgres and redis