### PR TITLE
Closes #84 - Fix chat greeting duplication bug

### DIFF
--- a/src/declarai/orchestrator/chat_orchestrator.py
+++ b/src/declarai/orchestrator/chat_orchestrator.py
@@ -49,7 +49,7 @@ class LLMChatOrchestrator:
         self.__set_memory()
 
     def __set_memory(self):
-        if self.greeting:
+        if self.greeting and len(self._chat_history.history) == 0:
             self.add_message(message=self.greeting, role=MessageRole.assistant)
 
     @property


### PR DESCRIPTION
We now add greeting only if the chat history len is 0.