### PR TITLE
Update test.yaml to disable comment on forks 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
         path: coverage.xml
 
     - name: Pytest coverage comment
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: MishaKav/pytest-coverage-comment@main
       with:
         pytest-coverage-path: ./pytest-coverage.txt


### PR DESCRIPTION
PR's from forks fail in the CI because they don't have the GITHUB_TOKEN that is necessary for the pytest-comment step to run. so for we disable that when the pull request head repo full name is not equal to the repository name.