### PR TITLE
fix : #96 Add support for both DECLARAI_OPEN_AI_KEY and OPENAI_API_KEY

### DIFF
--- a/src/declarai/operators/openai_operators/settings.py
+++ b/src/declarai/operators/openai_operators/settings.py
@@ -5,7 +5,9 @@ import os
 
 from declarai.core.core_settings import DECLARAI_PREFIX
 
-OPENAI_API_KEY: str = os.getenv(f"{DECLARAI_PREFIX}_OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", ""))  # pylint: disable=E1101
+OPENAI_API_KEY: str = os.getenv(
+    f"{DECLARAI_PREFIX}_OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", "")
+)  # pylint: disable=E1101
 "API key for openai provider."
 OPENAI_MODEL: str = os.getenv(
     f"{DECLARAI_PREFIX}_OPENAI_MODEL", "gpt-3.5-turbo"

--- a/src/declarai/operators/openai_operators/settings.py
+++ b/src/declarai/operators/openai_operators/settings.py
@@ -5,9 +5,7 @@ import os
 
 from declarai.core.core_settings import DECLARAI_PREFIX
 
-OPENAI_API_KEY: str = os.getenv(
-    f"{DECLARAI_PREFIX}_OPENAI_API_KEY", ""
-)  # pylint: disable=E1101
+OPENAI_API_KEY: str = os.getenv(f"{DECLARAI_PREFIX}_OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", ""))  # pylint: disable=E1101
 "API key for openai provider."
 OPENAI_MODEL: str = os.getenv(
     f"{DECLARAI_PREFIX}_OPENAI_MODEL", "gpt-3.5-turbo"


### PR DESCRIPTION
## Description

This pull request addresses issue #96 . It adds support for both `DECLARAI_OPEN_AI_KEY` and `OPENAI_API_KEY` environment variables in the `settings.py` file. This change ensures compatibility with existing workflows that utilize the `OPENAI_API_KEY` environment variable.

## Changes Made

- Modified the `settings.py` file to support both `DECLARAI_OPEN_AI_KEY` and `OPENAI_API_KEY`.
- Updated the code to check for the presence of either environment variable and use the appropriate value.

## Testing Done

- Tested the changes locally by setting different combinations of `DECLARAI_OPEN_AI_KEY` and `OPENAI_API_KEY` environment variables.
- Ran existing test suite to ensure that the changes did not introduce any regressions.

## Impact

This change improves the user experience by allowing users to utilize the more common `OPENAI_API_KEY` environment variable, while still providing support for the project-specific `DECLARAI_OPEN_AI_KEY`.

## Related Issues

Closes #96 