### PR TITLE
Enable azure openai llm. Closes #67 #72

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,5 +21,5 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: pip install -r requirements-docs.txt
-      - run: pip install git+https://${{ secrets.DECLARAI_MKDOCSTRINGS_INSIDERS_TOKEN }}@github.com/pawamoy-insiders/mkdocstrings-python.git@1.5.0.1.2.0
+      - run: pip install git+https://${{ secrets.DECLARAI_MKDOCSTRINGS_INSIDERS_TOKEN }}@github.com/pawamoy-insiders/mkdocstrings-python.git@1.6.0.1.4.0
       - run: mkdocs gh-deploy --force

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -20,3 +20,8 @@
 .md-banner a:hover {
     color: #e31849; /* Adjust this for the link hover color inside the banner */
 }
+
+/* Maximum space for text block */
+.md-grid {
+  max-width: 90%; /* or 100%, if you want to stretch to full-width */
+}

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -23,5 +23,5 @@
 
 /* Maximum space for text block */
 .md-grid {
-  max-width: 90%; /* or 100%, if you want to stretch to full-width */
+  max-width: 80%; /* or 100%, if you want to stretch to full-width */
 }

--- a/docs/providers/azure_openai.md
+++ b/docs/providers/azure_openai.md
@@ -1,34 +1,37 @@
-To use OpenAI models, you can set the following configuration options:
+To use Azure OpenAI models, you can set the following configuration options:
 
 ```py
 from declarai import Declarai
 
-azure = Declarai.openai(
-    openai_token="<api-token>",
-    model="<model>",
+azure = Declarai.azure_openai(
+    azure_openai_key="<api-token>",
+    azure_openai_api_base="<api-base>",
+    deployment_name="<deployment-name>",
     headers={"<header-key>": "<header-value>"},
     timeout="<timeout>",
     request_timeout="<request_timeout>",
     stream="<stream>", )
 ```
 
+| Setting         | <div style="width:180px">Env Variable</div> | <div style="width:280px">Runtime Variable</div>                     | Required? |
+|-----------------|---------------------------------------------|---------------------------------------------------------------------|:---------:|
+| API key         | `DECLARAI_AZURE_OPENAI_KEY`                 | `Declarai.azure_openai(... azure_openai_key=<api-token>)`           |     ✅     |
+| API_BASE        | `DECLARAI_AZURE_OPENAI_API_BASE`            | `Declarai.azure_openai(... azure_openai_api_base=<api-base>)`       |     ✅     |
+| API_VERSION     | `DECLARAI_AZURE_OPENAI_API_VERSION`         | `Declarai.azure_openai(... azure_openai_api_version=<api-version>)` |           |
+| DEPLOYMENT_NAME | `DECLARAI_AZURE_OPENAI_DEPLOYMENT_NAME`     | `Declarai.azure_openai(... deployment_name=<deployment-name>)`      |     ✅     |
+| Headers         |                                             | `Declarai.azure_openai(... headers=<headers>)`                      |           |
+| Timeout         |                                             | `Declarai.azure_openai(... timeout=<timeout>)`                      |           |
+| Request timeout |                                             | `Declarai.azure_openai(... request_timeout=<request_timeout>)`      |           |
+| Stream          |                                             | `Declarai.azure_openai(... stream=<stream>)`                        |           |
 
-| Setting         | <div style="width:180px">Env Variable</div> | <div style="width:280px">Runtime Variable</div>   | Required? |
-|-----------------|---------------------------------------------|---------------------------------------------------|:---------:|
-| API key         | `DECLARAI_OPENAI_API_KEY`                   | `Declarai(... openai_token=<api-token>)`          |     ✅     |
-| Headers         |                                             | `Declarai(... headers=<headers>)`                 |           |
-| Timeout         |                                             | `Declarai(... timeout=<timeout>)`                 |           |
-| Request timeout |                                             | `Declarai(... request_timeout=<request_timeout>)` |           |
-| Stream          |                                             | `Declarai(... stream=<stream>)`                   |           |
+## Getting an API key, API base, and Deployment name
 
-## Getting an API key
+To obtain the above settings, you will need to create an account on
+the [Azure OpenAI](https://azure.microsoft.com/en-us/services/cognitive-services/)
+website. Once you have created an account, you will need to create a resource.
 
-To obtain an OpenAI API key, follow these steps:
-
-1. [Log in](https://platform.openai.com/) to your OpenAI account (sign up if you don't have one)
-2. Go to the "API Keys" [page](https://platform.openai.com/account/api-keys) under your account settings.
-3. Click "Create new secret key." A new API key will be generated. Make sure to copy the key to your clipboard, as you
-   will not be able to see it again.
+Please follow the instructions on
+the [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/quickstart?tabs=command-line&pivots=programming-language-python)
 
 ## Setting the API key
 
@@ -37,16 +40,18 @@ You can set your API key at runtime like this:
 ```python
 from declarai import Declarai
 
-declarai = Declarai(provide="openai", model="gpt4", openai_token="<your API key>")
+declarai = Declarai.azure_openai(deployment_name="my-model",
+                                 azure_openai_key="<your API key>")
 ```
 
 However, it is preferable to pass sensitive settings as an environment variable: `DECLARAI_OPENAI_API_KEY`.
 
-To establish your OpenAI API key as an environment variable, launch your terminal and execute the following command,
+To establish your Azure OpenAI API key as an environment variable, launch your terminal and execute the following
+command,
 substituting <your API key> with your actual key:
 
 ```shell
-export DECLARAI_OPENAI_API_KEY=<your API key>
+export DECLARAI_AZURE_OPENAI_KEY=<your API key>
 ```
 
 This action will maintain the key for the duration of your terminal session. To ensure a longer retention, modify your
@@ -70,7 +75,12 @@ Pass your custom parameters to the declarai task/chat interface as a dictionary:
 ```python
 from declarai import Declarai
 
-declarai = Declarai(provide="openai", model="gpt4", openai_token="<your API key>")
+declarai = Declarai.azure_openai(
+    deployment_name="my-model",
+    azure_openai_key="<your API key>",
+    azure_openai_api_base="https://<my-azure-domain>.com",
+    headers="<my-headers>"
+)
 
 
 @declarai.task(llm_params={"temperature": 0.5, "max_tokens": 1000})  # (1)!

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -1,3 +1,4 @@
 Declarai supports the following providers:
     
 - [OpenAI](./openai.md)
+- [Azure OpenAI](./azure_openai.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Providers:
           - providers/index.md
           - providers/openai.md
+          - providers/azure_openai.md
       - Integrations:
           - integrations/index.md
       - Examples:

--- a/src/declarai/__init__.py
+++ b/src/declarai/__init__.py
@@ -1,1 +1,2 @@
 from .declarai import Declarai
+from .operators.registry import register_operator, register_llm

--- a/src/declarai/_base.py
+++ b/src/declarai/_base.py
@@ -1,3 +1,6 @@
+"""
+Base classes for declarai tasks.
+"""
 from abc import abstractmethod
 from typing import Any, TypeVar
 
@@ -78,6 +81,7 @@ class BaseChat(BaseTask):
     """
 
     operator: BaseChatOperator
+    "The operator to use for the chat task."
 
 
 TaskType = TypeVar("TaskType", bound=BaseTask)

--- a/src/declarai/core/__init__.py
+++ b/src/declarai/core/__init__.py
@@ -1,0 +1,3 @@
+"""
+Core settings for Declarai.
+"""

--- a/src/declarai/declarai.py
+++ b/src/declarai/declarai.py
@@ -1,8 +1,20 @@
-"""This is the main entry point for declarai. It is used to decorate the package functionalities and serve as the main interface for the user. """
-from typing import Any, Dict, Optional, overload
+"""Main interface for declarai.
+
+Decorates the package functionalities and serve as the main interface for the user.
+"""
+from typing import Any, Dict, Optional, Type, overload
 
 from declarai.chat import ChatDecorator
-from declarai.operators import LLMSettings, ModelsOpenai, ProviderOpenai
+from declarai.operators import (
+    LLM,
+    BaseOperator,
+    ModelsOpenai,
+    ProviderAzureOpenai,
+    ProviderOpenai,
+    llm_registry,
+    operator_registry,
+    resolve_llm,
+)
 from declarai.task import TaskDecorator
 
 
@@ -29,50 +41,179 @@ def magic(
     pass
 
 
+class DeclaraiContext:
+    """
+    Context manager for the Declarai root interface.
+    This class is responsible for setting up tasks and initializing experimental features
+    provided by Declarai.
+
+    Args:
+        provider (str): The provider name.
+        model (str): The model name.
+        **kwargs: Additional keyword arguments passed to the LLM resolver.
+
+    Attributes:
+        llm (LLM): Resolved LLM.
+        task (Callable): A decorator for task creation.
+        experimental: A namespace for experimental features.
+        experimental.chat (Callable): A decorator for chat operators.
+    """
+
+    def __init__(self, provider: str, model: str = None, **kwargs):
+        self.llm = resolve_llm(provider, model, **kwargs)
+        self.task = TaskDecorator(self.llm).task
+
+        class Experimental:
+            chat = ChatDecorator(self.llm).chat
+
+        self.experimental = Experimental
+
+
 class Declarai:
     """
     A root interface to declarai.
-    This class allows creating tasks and other declarai provided tools.
+    This class is a factory to build declarai context.
 
-    There are overloads for the constructor that allow for a more declarative way of creating tasks.
+    There are overloads for the constructor that allow for a more declarative way of building the declarai context
     based on the provider and model.
 
     Args:
         **kwargs: A set of keyword arguments that are passed to the LLMSettings class.
 
-    Attributes:
-        llm_settings (LLMSettings): A settings object that is used to configure the LLM.
-        task (Callable): A decorator that is used to create tasks.
-        experimental (Any): A namespace for experimental features.
-        experimental.chat (Callable): A decorator that is used to create chat operators.
-
     """
 
     magic = magic
+
+    @overload
+    def __new__(
+        cls,
+        provider: ProviderOpenai,
+        model: ModelsOpenai,
+        version: Optional[str] = None,
+        openai_token: Optional[str] = None,
+    ) -> DeclaraiContext:
+        ...
+
+    def __new__(cls, *args, **kwargs) -> DeclaraiContext:
+        """
+        Creates a declarai context.
+
+        Args:
+            *args:
+            **kwargs:
+        """
+        return DeclaraiContext(*args, **kwargs)
 
     # *-------------------------------------------------------------------------- *
     # * Custom overloads to enforce the relationship between PROVIDER and MODELS  *
     # * Additionally supported providers should be exposed via the Declarai class *
     # * here:                                                                     *
     # *-------------------------------------------------------------------------- *
-    @overload
-    def __init__(
-        self,
-        provider: ProviderOpenai,
+
+    @staticmethod
+    def openai(
         model: ModelsOpenai,
-        version: Optional[str] = None,
-        openai_token: Optional[str] = None,
+        version: str = None,
+        openai_token: str = None,
+        headers: dict = None,
+        timeout: int = None,
+        stream: bool = None,
+        request_timeout: int = None,
+    ) -> DeclaraiContext:
+        """
+        Sets up a Declarai context for the OpenAI provider.
+
+        Args:
+            model (ModelsOpenai): The model to be used.
+            version (str, optional): Model version.
+            openai_token (str, optional): OpenAI authentication token.
+            headers (dict, optional): Additional headers for the request.
+            timeout (int, optional): Timeout for the request.
+            stream (bool, optional): Whether to stream the response.
+            request_timeout (int, optional): Request timeout duration.
+
+        Returns:
+            DeclaraiContext: Initialized Declarai context.
+        """
+        return DeclaraiContext(
+            provider=ProviderOpenai,
+            model=model,
+            version=version,
+            openai_token=openai_token,
+            headers=headers,
+            timeout=timeout,
+            stream=stream,
+            request_timeout=request_timeout,
+        )
+
+    @staticmethod
+    def azure_openai(
+        deployment_name: str,
+        azure_openai_key: str = None,
+        azure_openai_api_base: str = None,
+        api_version: str = None,
+        headers: dict = None,
+        timeout: int = None,
+        stream: bool = None,
+        request_timeout: int = None,
+    ) -> DeclaraiContext:
+        """
+        Sets up a Declarai context for the Azure OpenAI provider.
+
+        Args:
+            deployment_name (str): Name of the deployment.
+            azure_openai_key (str, optional): Azure OpenAI key.
+            azure_openai_api_base (str, optional): Base API URL for Azure OpenAI.
+            api_version (str, optional): API version.
+            headers (dict, optional): Additional headers for the request.
+            timeout (int, optional): Timeout for the request.
+            stream (bool, optional): Whether to stream the response.
+            request_timeout (int, optional): Request timeout duration.
+
+        Returns:
+            DeclaraiContext: Initialized Declarai context.
+        """
+        return DeclaraiContext(
+            provider=ProviderAzureOpenai,
+            model=deployment_name,
+            azure_openai_key=azure_openai_key,
+            azure_openai_api_base=azure_openai_api_base,
+            api_version=api_version,
+            headers=headers,
+            timeout=timeout,
+            stream=stream,
+            request_timeout=request_timeout,
+        )
+
+    @staticmethod
+    def register_llm(provider: str, llm_cls: Type[LLM], model: str = None):
+        """
+        Registers an LLM.
+        Args:
+            provider: Name of the LLM provider.
+            model: Specific model name (optional).
+            llm_cls: The LLM class to register.
+        """
+        llm_registry.register(provider=provider, llm_cls=llm_cls, model=model)
+
+    @staticmethod
+    def register_operator(
+        provider: str,
+        operator_type: str,
+        operator_cls: Type[BaseOperator],
+        model: str = None,
     ):
-        ...
-
-    # *-------------------------------------------------------------------------- *
-    # * Actual implementation of Declarai                                         *
-    # *-------------------------------------------------------------------------- *
-    def __init__(self, **kwargs):
-        self.llm_settings = LLMSettings(**kwargs)
-        self.task = TaskDecorator(self.llm_settings, **kwargs).task
-
-        class Experimental:
-            chat = ChatDecorator(self.llm_settings, **kwargs).chat
-
-        self.experimental = Experimental
+        """
+        Registers an operator.
+        Args:
+            provider: Name of the LLM provider.
+            operator_type: The type of operator (e.g., "chat", "task").
+            operator_cls: The operator class to register.
+            model: Specific model name
+        """
+        operator_registry.register(
+            provider=provider,
+            operator_type=operator_type,
+            model=model,
+            operator_cls=operator_cls,
+        )

--- a/src/declarai/evals/__init__.py
+++ b/src/declarai/evals/__init__.py
@@ -1,0 +1,3 @@
+"""
+Evaluation suite module for DeclarAI.
+"""

--- a/src/declarai/memory/__init__.py
+++ b/src/declarai/memory/__init__.py
@@ -1,3 +1,6 @@
+"""
+Memory module for Declarai interactions that includes message history.
+"""
 from .file import FileMessageHistory
 from .in_memory import InMemoryMessageHistory
 from .mongodb import MongoDBMessageHistory

--- a/src/declarai/middleware/__init__.py
+++ b/src/declarai/middleware/__init__.py
@@ -1,0 +1,5 @@
+"""
+Middleware module for Declarai.
+
+Middlewares are used to extend the functionality of the Declarai execution flow.
+"""

--- a/src/declarai/middleware/internal/__init__.py
+++ b/src/declarai/middleware/internal/__init__.py
@@ -1,1 +1,4 @@
+"""
+Middlewares offered by Declarai that does not require external dependencies.
+"""
 from .log_middleware import LoggingMiddleware

--- a/src/declarai/middleware/internal/log_middleware.py
+++ b/src/declarai/middleware/internal/log_middleware.py
@@ -13,6 +13,7 @@ logger = logging.getLogger("PromptLogger")
 class LoggingMiddleware(TaskMiddleware):
     """
     Creates a Simple logging middleware for a given task.
+
     Example:
         ```py
         @declarai.task(middlewares=[LoggingMiddleware])

--- a/src/declarai/middleware/third_party/__init__.py
+++ b/src/declarai/middleware/third_party/__init__.py
@@ -1,1 +1,4 @@
+"""
+Middlewares offered that requires external dependencies.
+"""
 from .wandb_monitor import WandDBMonitorCreator

--- a/src/declarai/operators/llm.py
+++ b/src/declarai/operators/llm.py
@@ -66,7 +66,7 @@ class LLMSettings:
         self.version = version
 
     @property
-    def model(self, delimiter: Optional[str] = "-") -> str:
+    def model(self, delimiter: Optional[str] = "-", with_version: bool = True) -> str:
         """
         Some model providers allow defining a base model as well as a sub-model.
         Often the base model is an alias to latest model served on that model.
@@ -91,7 +91,7 @@ class LLMSettings:
         In any case you can always pass the full model name in the model parameter and leave the
         sub_model parameter empty if you prefer.
         """
-        if self.version:
+        if self.version and with_version:
             return f"{self._model}{delimiter}{self.version}"
         return self._model
 

--- a/src/declarai/operators/openai_operators/__init__.py
+++ b/src/declarai/operators/openai_operators/__init__.py
@@ -1,3 +1,6 @@
-from .chat_operator import OpenAIChatOperator
-from .openai_llm import OpenAIError, OpenAILLM, OpenAILLMParams
-from .task_operator import OpenAITaskOperator
+"""
+OpenAI operators and LLMs.
+"""
+from .chat_operator import AzureOpenAIChatOperator, OpenAIChatOperator
+from .openai_llm import AzureOpenAILLM, OpenAIError, OpenAILLM, OpenAILLMParams
+from .task_operator import AzureOpenAITaskOperator, OpenAITaskOperator

--- a/src/declarai/operators/openai_operators/chat_operator.py
+++ b/src/declarai/operators/openai_operators/chat_operator.py
@@ -5,17 +5,18 @@ import logging
 from typing import List
 
 from declarai.operators import Message, MessageRole
+from declarai.operators.openai_operators.openai_llm import AzureOpenAILLM, OpenAILLM
 from declarai.operators.operator import BaseChatOperator, CompiledTemplate
+from declarai.operators.registry import register_operator
 from declarai.operators.templates import (
     StructuredOutputChatPrompt,
     compile_output_prompt,
 )
 
-from .openai_llm import OpenAILLM
-
 logger = logging.getLogger("OpenAIChatOperator")
 
 
+@register_operator(provider="openai", operator_type="chat")
 class OpenAIChatOperator(BaseChatOperator):
     """
     Chat implementation of OpenAI operator. This is a child of the BaseChatOperator class. See the BaseChatOperator class for further documentation.
@@ -74,3 +75,15 @@ class OpenAIChatOperator(BaseChatOperator):
             Message(message=compiled_system_prompt, role=MessageRole.system)
         ] + messages
         return {"messages": messages}
+
+
+@register_operator(provider="azure-openai", operator_type="chat")
+class AzureOpenAIChatOperator(OpenAIChatOperator):
+    """
+    Chat implementation of OpenAI operator. This is a child of the BaseChatOperator class. See the BaseChatOperator class for further documentation.
+
+    Attributes:
+        llm: AzureOpenAILLM
+    """
+
+    llm: AzureOpenAILLM

--- a/src/declarai/operators/openai_operators/settings.py
+++ b/src/declarai/operators/openai_operators/settings.py
@@ -1,7 +1,9 @@
 """
-Environment level configurations for working with openai provider.
+Environment level configurations for working with openai and Azure openai providers.
 """
 import os
+
+import openai
 
 from declarai.core.core_settings import DECLARAI_PREFIX
 
@@ -9,7 +11,33 @@ OPENAI_API_KEY: str = os.getenv(
     f"{DECLARAI_PREFIX}_OPENAI_API_KEY", os.getenv("OPENAI_API_KEY", "")
 )  # pylint: disable=E1101
 "API key for openai provider."
+
 OPENAI_MODEL: str = os.getenv(
     f"{DECLARAI_PREFIX}_OPENAI_MODEL", "gpt-3.5-turbo"
 )  # pylint: disable=E1101
 "Model name for openai provider."
+
+# Azure specific configurations
+AZURE_OPENAI_KEY: str = os.getenv(
+    f"{DECLARAI_PREFIX}_AZURE_OPENAI_KEY", os.getenv("AZURE_OPENAI_KEY", "")
+)  # pylint: disable=E1101
+"API key for Azure openai provider."
+
+AZURE_OPENAI_API_BASE: str = os.getenv(
+    f"{DECLARAI_PREFIX}_AZURE_OPENAI_API_BASE",
+    os.getenv("AZURE_OPENAI_API_BASE", ""),
+)  # pylint: disable=E1101
+"Endpoint for Azure openai provider."
+
+AZURE_API_VERSION: str = os.getenv(
+    f"{DECLARAI_PREFIX}_AZURE_API_VERSION",
+    os.getenv("AZURE_API_VERSION", openai.api_version),
+)  # pylint: disable=E1101
+"API version for Azure openai provider."
+
+
+DEPLOYMENT_NAME: str = os.getenv(
+    f"{DECLARAI_PREFIX}_DEPLOYMENT_NAME",
+    os.getenv("DEPLOYMENT_NAME", ""),
+)  # pylint: disable=E1101
+"Deployment name for the model in Azure openai provider."

--- a/src/declarai/operators/openai_operators/settings.py
+++ b/src/declarai/operators/openai_operators/settings.py
@@ -37,7 +37,7 @@ AZURE_API_VERSION: str = os.getenv(
 
 
 DEPLOYMENT_NAME: str = os.getenv(
-    f"{DECLARAI_PREFIX}_DEPLOYMENT_NAME",
+    f"{DECLARAI_PREFIX}_AZURE_OPENAI_DEPLOYMENT_NAME",
     os.getenv("DEPLOYMENT_NAME", ""),
 )  # pylint: disable=E1101
 "Deployment name for the model in Azure openai provider."

--- a/src/declarai/operators/openai_operators/task_operator.py
+++ b/src/declarai/operators/openai_operators/task_operator.py
@@ -3,6 +3,7 @@ Task implementation for openai operator.
 """
 import logging
 
+from declarai.operators.registry import register_operator
 from declarai.operators.message import Message, MessageRole
 from declarai.operators.operator import BaseOperator, CompiledTemplate
 from declarai.operators.templates import (
@@ -11,7 +12,7 @@ from declarai.operators.templates import (
     compile_output_prompt,
 )
 
-from .openai_llm import OpenAILLM
+from .openai_llm import AzureOpenAILLM, OpenAILLM
 
 logger = logging.getLogger("OpenAITaskOperator")
 
@@ -20,6 +21,7 @@ INPUT_LINE_TEMPLATE = "{param}: {{{param}}}"
 NEW_LINE_INPUT_LINE_TEMPLATE = "\n{param}: {{{param}}}"
 
 
+@register_operator(provider="openai", operator_type="task")
 class OpenAITaskOperator(BaseOperator):
     """
     Task implementation for openai operator. This is a child of the BaseOperator class. See the BaseOperator class for further documentation.
@@ -124,3 +126,15 @@ class OpenAITaskOperator(BaseOperator):
             template[-1].message = template[-1].message.format(**kwargs)
             return {"messages": template}
         return {"messages": template}
+
+
+@register_operator(provider="azure-openai", operator_type="task")
+class AzureOpenAITaskOperator(OpenAITaskOperator):
+    """
+    Task implementation for openai operator that uses Azure as the llm provider.
+
+    Attributes:
+        llm: AzureOpenAILLM
+    """
+
+    llm: AzureOpenAILLM

--- a/src/declarai/operators/operator.py
+++ b/src/declarai/operators/operator.py
@@ -102,7 +102,9 @@ class BaseChatOperator(BaseOperator):
         parsed_send_func (PythonParser): The parsed object that is used to compile the send function.
     """
 
-    def __init__(self, system: str, greeting: Optional[str] = None, **kwargs):
+    def __init__(
+        self, system: Optional[str] = None, greeting: Optional[str] = None, **kwargs
+    ):
         super().__init__(**kwargs)
         self.system = system or self.parsed.docstring_freeform
         self.greeting = greeting or getattr(self.parsed.decorated, "greeting", None)

--- a/src/declarai/operators/registry.py
+++ b/src/declarai/operators/registry.py
@@ -1,0 +1,187 @@
+"""
+Registry for LLMs and Operators.
+"""
+from collections import defaultdict
+from typing import Type, Optional
+
+from declarai.operators.llm import LLM
+from declarai.operators.operator import BaseOperator
+
+
+class LLMRegistry:
+    """
+    Registry for LLMs.
+    The registry will have a nested structure: {provider: {model: llm_cls}}
+    But it will also support a direct provider-to-llm_cls mapping for generic LLMs.
+    But it will also support a direct provider-to-llm_cls mapping for generic LLMs.
+    """
+
+    def __init__(self):
+        self._registry = defaultdict(dict)
+
+    def register(
+        self, provider: str, llm_cls: Type[LLM], model: Optional[str] = "default"
+    ):
+        """
+        Registers an LLM.
+        Args:
+            provider: the name of the LLM provider.
+            llm_cls: the LLM class to register.
+            model: the specific model name.
+
+        Returns:
+            None
+
+        """
+        self._registry[provider][model] = llm_cls
+
+    def resolve(self, provider: str, model: Optional[str] = None, **kwargs) -> LLM:
+        """
+        Resolves an LLM. If the model is not specified, the default model of the given provider will be used.
+        Args:
+            provider: the name of the LLM provider.
+            model: the specific model name.
+            **kwargs: Additional keyword arguments to pass to the LLM initialization.
+
+        Returns:
+            An LLM instance.
+        """
+        if not model:
+            model = "default"
+        provider_registry = self._registry.get(provider, {})
+
+        llm_cls = provider_registry.get(model)
+        if not llm_cls:
+            # If the specific model isn't found, fall back to the default.
+            llm_cls = provider_registry.get("default")
+
+        if not llm_cls:
+            raise NotImplementedError(
+                f"LLMProvider : {provider} or model: {model} not implemented"
+            )
+        try:
+            return llm_cls(model=model, **kwargs)
+        except TypeError:
+            return llm_cls(**kwargs)
+
+
+llm_registry = LLMRegistry()
+"""The global LLM registry."""
+
+
+# Example registrations
+# For a provider that supports all models with the same LLM:
+# llm_registry.register(ProviderOpenai, llm_cls=GenericOpenAILLM)
+
+# For a specific model under a provider:
+# llm_registry.register(ProviderAzureOpenai, model="azure-specific-model", llm_cls=AzureSpecificLLM)
+
+
+# Operator Registry
+class OperatorRegistry:
+    """
+    Registry for Operators.
+    The registry will have a nested structure: {provider: {operator_type: {model: operator_cls}}}
+    It will support a direct provider-to-operator_cls mapping for generic Operators.
+    """
+
+    def __init__(self):
+        self._registry = defaultdict(lambda: defaultdict(dict))
+
+    def register(
+        self,
+        provider: str,
+        operator_type: str,
+        operator_cls: Type[BaseOperator],
+        model: str = "default",
+    ):
+        """
+        Registers an operator.
+
+        Args:
+            provider: the name of the operator provider.
+            operator_type: the type of the operator.
+            operator_cls: the operator class to register.
+            model: the specific model name that the operator is registered to.
+
+        Returns:
+            None
+
+        """
+        self._registry[provider][operator_type][model] = operator_cls
+
+    def resolve(self, llm_instance: LLM, operator_type: str) -> Type[BaseOperator]:
+        """
+        Resolves an operator.
+
+        Args:
+            llm_instance: An LLM instance.
+            operator_type: A string representing the type of the operator.
+
+        Returns:
+            An operator class.
+
+        """
+        default_model = "default"
+        provider = llm_instance.provider
+        operator_registry = self._registry.get(provider, {})
+
+        specific_operator_registry = operator_registry.get(operator_type, {})
+        operator_cls = specific_operator_registry.get(llm_instance.model)
+
+        if not operator_cls:
+            # If the specific model isn't found, fall back to the default.
+            operator_cls = specific_operator_registry.get(default_model)
+
+        if not operator_cls:
+            raise NotImplementedError(
+                f"Operator type : {operator_type} for provider: {provider} or model: {llm_instance.model} not implemented"
+            )
+
+        return operator_cls
+
+
+operator_registry = OperatorRegistry()
+"""The global Operator registry."""
+
+
+def register_llm(provider: str, model: Optional[str] = "default"):
+    """
+    A decorator that registers an LLM class to the LLM registry.
+
+    Args:
+        provider: the name of the LLM provider.
+        model: the specific model name.
+
+    Returns:
+        A decorator that registers the decorated LLM class to the LLM registry.
+    """
+
+    def decorator(cls):
+        llm_registry.register(provider, cls, model)
+        return cls
+
+    return decorator
+
+
+def register_operator(
+    provider: str, operator_type: str, model: Optional[str] = "default"
+):
+    """
+    A decorator that registers an operator class to the operator registry.
+
+    Args:
+        provider: the name of the operator provider.
+        operator_type: the string representing the type of the operator.
+        model: the specific model name.
+
+    Returns:
+        A decorator that registers the decorated operator class to the operator registry.
+
+    """
+
+    def decorator(cls):
+        operator_registry.register(provider, operator_type, cls, model)
+        return cls
+
+    return decorator

--- a/src/declarai/operators/templates/__init__.py
+++ b/src/declarai/operators/templates/__init__.py
@@ -1,3 +1,6 @@
+"""
+This module contains the shared templates for the operators.
+"""
 from .chain_of_thought import ChainOfThoughtsTemplate
 from .instruct_function import InstructFunctionTemplate
 from .output_prompt import compile_output_prompt, compile_output_schema_template

--- a/src/declarai/python_parser/__init__.py
+++ b/src/declarai/python_parser/__init__.py
@@ -1,1 +1,4 @@
+"""
+Internal package for parsing User Python code into a ParsedFunction object.
+"""
 # from .parsers import ParsedFunction

--- a/src/declarai/task.py
+++ b/src/declarai/task.py
@@ -1,4 +1,4 @@
-"""Task
+"""Task interface
 
 Provides the most basic component to interact with an LLM.
 LLMs are often interacted with via an API. In order to provide prompts and receive predictions,
@@ -18,10 +18,10 @@ from typing import Any, Callable, Dict, List, Optional, Type, overload
 from declarai._base import BaseTask
 from declarai.middleware.base import TaskMiddleware
 from declarai.operators import (
+    LLM,
     BaseOperator,
     LLMParamsType,
     LLMResponse,
-    LLMSettings,
     resolve_operator,
 )
 from declarai.python_parser.parser import PythonParser
@@ -182,9 +182,8 @@ class TaskDecorator:
         task: the decorator that creates the task
     """
 
-    def __init__(self, llm_settings: LLMSettings, **kwargs):
-        self.llm_settings = llm_settings
-        self._kwargs = kwargs
+    def __init__(self, llm: LLM):
+        self.llm = llm
 
     @staticmethod
     @overload
@@ -221,14 +220,12 @@ class TaskDecorator:
             (Task): the task that was created
 
         """
-        operator_type, llm = resolve_operator(
-            self.llm_settings, operator_type="task", **self._kwargs
-        )
+        operator_type = resolve_operator(self.llm, operator_type="task")
 
         def wrap(_func: Callable) -> Task:
             operator = operator_type(
                 parsed=PythonParser(_func),
-                llm=llm,
+                llm=self.llm,
                 llm_params=llm_params,
             )
             llm_task = Task(operator=operator, middlewares=middlewares)

--- a/tests/api/test_chat_decorator.py
+++ b/tests/api/test_chat_decorator.py
@@ -4,8 +4,9 @@ from declarai import Declarai
 from declarai.operators import Message, MessageRole
 
 
+@patch("declarai.declarai.resolve_llm")
 @patch("declarai.chat.resolve_operator")
-def test_chat(mock_chat_resolve_operator):
+def test_chat(mock_chat_resolve_operator, mock_resolve_llm):
     operator_class_mock = MagicMock()
     operator_instance_mock = MagicMock()
 
@@ -15,7 +16,8 @@ def test_chat(mock_chat_resolve_operator):
     operator_class_mock.return_value = operator_instance_mock
 
     llm = MagicMock()
-    mock_chat_resolve_operator.return_value = (operator_class_mock, llm)
+    mock_chat_resolve_operator.return_value = operator_class_mock
+    mock_resolve_llm.return_value = llm
     declarai = Declarai(provider="test", model="test")
 
     @declarai.experimental.chat

--- a/tests/api/test_task_decorator.py
+++ b/tests/api/test_task_decorator.py
@@ -7,7 +7,6 @@ from declarai.task import TaskDecorator
 @patch("declarai.task.PythonParser")
 @patch("declarai.task.resolve_operator")
 def test_task_decorator_no_args(mocked_resolve_operator, mocked_python_parser):
-    llm_settings = MagicMock()
     operator_class_mock = MagicMock()
     operator_instance_mock = MagicMock()
     llm = MagicMock()
@@ -17,12 +16,12 @@ def test_task_decorator_no_args(mocked_resolve_operator, mocked_python_parser):
     mocked_python_parser.return_value = MagicMock()
     operator_instance_mock.parsed = mocked_python_parser.return_value
     operator_class_mock.return_value = operator_instance_mock
-    mocked_resolve_operator.return_value = (operator_class_mock, llm)
+    mocked_resolve_operator.return_value = operator_class_mock
 
     middlewares = [middleware]
 
     task_decorator = TaskDecorator(
-        llm_settings=llm_settings, middlewares=middlewares
+        llm=llm
     )
     decorator = task_decorator.task
 
@@ -38,7 +37,7 @@ def test_task_decorator_no_args(mocked_resolve_operator, mocked_python_parser):
         """
         return magic("return_name", a=a, b=b)
 
-    assert task_decorator.llm_settings == llm_settings
+    assert task_decorator.llm == llm
     assert test_task.middlewares == middlewares
     assert test_task.__name__ == "test_task"
     assert test_task.operator.parsed == mocked_python_parser.return_value

--- a/tests/operators/openai_operators/test_chat_operator.py
+++ b/tests/operators/openai_operators/test_chat_operator.py
@@ -1,0 +1,40 @@
+from declarai.operators import OpenAILLM, OpenAIChatOperator
+from declarai.python_parser.parser import PythonParser
+
+
+def test_chat_openai_operator():
+    openai_operator_class = OpenAIChatOperator
+    llm = OpenAILLM(
+        openai_token="test-token",
+        model="test-model",
+    )
+
+    class MyChat:
+        """
+        This is my beloved chat
+        """
+
+    parsed = PythonParser(MyChat)
+    openai_operator_instance = openai_operator_class(parsed=parsed, llm=llm)
+    assert openai_operator_instance.parsed.name == MyChat.__name__
+    compiled = openai_operator_instance.compile(messages=[])
+    assert isinstance(compiled, dict)
+    messages = list(compiled["messages"])
+    assert len(messages) == 1
+    assert (
+        messages[0].message == "This is my beloved chat"
+    )
+    assert messages[0].role == "system"
+
+    # def openai_task():
+    #     ...
+    #
+    # parsed = PythonParser(openai_task)
+    # openai_operator_instance = openai_operator_class(parsed=parsed, llm=llm)
+    # assert openai_operator_instance.parsed.name == openai_task.__name__
+    # compiled = openai_operator_instance.compile()
+    # assert isinstance(compiled, dict)
+    # messages = list(compiled["messages"])
+    # assert len(messages) == 1
+    # assert messages[0].message == "\n\n"
+    # assert messages[0].role == "user"

--- a/tests/operators/openai_operators/test_operator.py
+++ b/tests/operators/openai_operators/test_operator.py
@@ -1,4 +1,4 @@
-from declarai.operators import OpenAITaskOperator, OpenAILLM
+from declarai.operators import OpenAILLM, OpenAITaskOperator
 from declarai.python_parser.parser import PythonParser
 
 

--- a/tests/operators/shared/test_output_prompt.py
+++ b/tests/operators/shared/test_output_prompt.py
@@ -1,8 +1,7 @@
 import pytest
 
 from declarai.operators.openai_operators.task_operator import compile_output_prompt
-from declarai.operators.templates import compile_output_schema_template
-from declarai.operators.templates import StructuredOutputInstructionPrompt
+from declarai.operators.templates import StructuredOutputInstructionPrompt, compile_output_schema_template
 
 
 @pytest.mark.parametrize(

--- a/tests/operators/test_operator_resolver.py
+++ b/tests/operators/test_operator_resolver.py
@@ -3,19 +3,17 @@ from unittest.mock import patch
 
 import pytest
 
-from declarai.operators import resolve_operator
-from declarai.operators import LLMSettings
-from declarai.operators.openai_operators import OpenAITaskOperator
-from declarai.operators.openai_operators import OpenAIError
+from declarai.operators import LLMSettings, resolve_operator, resolve_llm, AzureOpenAITaskOperator
+from declarai.operators.openai_operators import OpenAIError, OpenAITaskOperator
 
 
 def test_resolve_openai_operator_with_token():
     kwargs = {"openai_token": "test_token"}
-    llm_settings = LLMSettings(provider="openai", model="davinci")
-    operator, llm = resolve_operator(llm_settings, operator_type="task", **kwargs)
+    llm = resolve_llm(provider="openai", model="davinci", **kwargs)
+    operator = resolve_operator(llm_instance=llm, operator_type="task")
     assert operator == OpenAITaskOperator
     assert llm.model == "davinci"
-    assert llm.openai.api_key  == kwargs["openai_token"]
+    assert llm.api_key == kwargs["openai_token"]
 
 
 @patch(
@@ -23,12 +21,23 @@ def test_resolve_openai_operator_with_token():
     "test_token",
 )
 def test_resolve_openai_operator_without_token():
-    llm_settings = LLMSettings(provider="openai", model="davinci")
-    operator, llm = resolve_operator(llm_settings, operator_type="task")
+    llm = resolve_llm(provider="openai", model="davinci")
+    operator = resolve_operator(llm, operator_type="task")
     assert operator == OpenAITaskOperator
 
 
 def test_resolve_openai_operator_no_token_raises_error():
     with pytest.raises(OpenAIError):
-        llm_settings = LLMSettings(provider="openai", model="davinci")
-        resolve_operator(llm_settings, operator_type="task")
+        llm = resolve_llm(provider="openai", model="davinci")
+        resolve_operator(llm, operator_type="task")
+
+
+def test_resolve_azure_operator():
+    llm = resolve_llm(
+        provider="azure-openai",
+        model="test",
+        azure_openai_key="123",
+        azure_openai_api_base="456",
+    )
+    operator = resolve_operator(llm, operator_type="task")
+    assert operator == AzureOpenAITaskOperator

--- a/tests/operators/test_resolve_llm.py
+++ b/tests/operators/test_resolve_llm.py
@@ -1,0 +1,9 @@
+import pytest
+
+from declarai.operators.openai_operators import OpenAIError
+from declarai.operators import resolve_llm
+
+
+def test_resolve_openai_operator_no_token_raises_error():
+    with pytest.raises(OpenAIError):
+        resolve_llm(provider="openai", model="davinci")

--- a/tests/python_parser/annotations/test_type_annotation_to_schema.py
+++ b/tests/python_parser/annotations/test_type_annotation_to_schema.py
@@ -3,9 +3,7 @@ from typing import Any, Dict, List
 import pytest
 from pydantic import BaseModel, Field
 
-from declarai.python_parser.type_annotation_to_schema import (
-    type_annotation_to_str_schema,
-)
+from declarai.python_parser.type_annotation_to_schema import type_annotation_to_str_schema
 
 
 class MockSimpleModel(BaseModel):

--- a/tests/tasks/test_llm_chat.py
+++ b/tests/tasks/test_llm_chat.py
@@ -2,19 +2,10 @@
 #
 # from pytest import fixture
 #
-# from declarai.operators.base.types import Message
-# from declarai.tasks.llm_chat import LLMChat
+# from declarai.operators import Message
+# from declarai.chat import Chat
 #
-# CHAT_TEMPLATE = "{system_prompt}{output_instructions}"
-# TEMPLATE_KWARGS = {
-#     "system_prompt": "You are an assistant making people laugh.",
-#     "output_instructions": "",
-# }
 #
-# SYSTEM_MESSAGE = Message(
-#     message="You are an assistant making people laugh.",
-#     role="system",
-# )
 #
 #
 # def test_chat_message():
@@ -34,10 +25,9 @@
 # def llm_chat():
 #     test_llm = MagicMock()
 #     test_llm.predict.return_value = MagicMock()
-#     llm_chat = LLMChat(
-#         template=CHAT_TEMPLATE,
-#         template_kwargs=TEMPLATE_KWARGS,
-#         llm=test_llm,
+#     llm_chat = Chat(
+#         system="You are a translator from english to french",
+#         operator,
 #         prompt_kwargs={"structured": False},
 #     )
 #     return llm_chat

--- a/tests/test_declarai.py
+++ b/tests/test_declarai.py
@@ -3,18 +3,53 @@ from unittest.mock import MagicMock, patch
 from declarai import Declarai
 
 
-@patch("declarai.task.resolve_operator")
+@patch("declarai.declarai.resolve_llm")
 @patch("declarai.declarai.TaskDecorator")
-@patch("declarai.declarai.LLMSettings")
-def test_declarai(mocked_llm_settings, mocked_task_decorator, _):
+def test_declarai(mocked_task_decorator, mocked_resolve_llm):
     kwargs = {}
-    mocked_llm_settings.return_value = MagicMock()
+    mocked_resolve_llm.return_value = MagicMock()
     mocked_task_decorator.return_value.task = MagicMock()
 
-    declarai = Declarai(**kwargs)
+    declarai = Declarai(provider="test",
 
-    assert declarai.llm_settings == mocked_llm_settings.return_value
+                        **kwargs)
+
+    assert declarai.llm == mocked_resolve_llm.return_value
     assert declarai.task == mocked_task_decorator.return_value.task
 
     # Test experimental apis
     assert declarai.experimental
+
+
+def test_declarai_openai():
+    kwargs = {
+        "model": "davinci",
+        "openai_token": "test_token"
+    }
+    declarai = Declarai.openai(
+        **kwargs
+    )
+
+    assert declarai.llm.provider == "openai"
+    assert declarai.llm.model == "davinci"
+    assert declarai.llm.api_key == "test_token"
+
+
+
+def test_declarai_azure_openai():
+    kwargs = {
+        "deployment_name": "test",
+        "azure_openai_key": "123",
+        "azure_openai_api_base": "456",
+        "api_version": "789",
+    }
+    declarai = Declarai.azure_openai(
+        **kwargs
+    )
+
+    assert declarai.llm.provider == "azure-openai"
+    assert declarai.llm.model == "test"
+    assert declarai.llm.api_key == "123"
+    assert declarai.llm._kwargs["api_base"] == "456"
+    assert declarai.llm._kwargs["api_version"] == "789"
+


### PR DESCRIPTION
1. Support azure openai llm.
2. Support headers/timeout/stream etc.. for openai sdk.
3. Refactor llm and operators to work with registries and therefore enable custom llm + operators.